### PR TITLE
Add showLabels parameter to control label visibility in Sankey diagrams

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -128,6 +128,7 @@ class _SankeyComplexDiagramWidgetState
           selectedNodeId: selectedNodeId,
           onNodeTap: _handleNodeTap,
           size: const Size(1000, 600),
+          showLabels: false,
         ),
       ),
     );

--- a/lib/interactive_sankey_painter.dart
+++ b/lib/interactive_sankey_painter.dart
@@ -6,7 +6,7 @@ import 'package:sankey_flutter/sankey_node.dart';
 import 'package:sankey_flutter/sankey_painter.dart';
 
 /// A [SankeyPainter] subclass that adds interactivity:
-/// 
+///
 /// - Supports custom node colors per label
 /// - Highlights connected links when a node is selected
 /// - Applies hover/focus feedback with opacity and borders
@@ -22,8 +22,10 @@ class InteractiveSankeyPainter extends SankeyPainter {
     required List<SankeyLink> links,
     required this.nodeColors,
     this.selectedNodeId,
+    bool showLabels = true,
     Color linkColor = Colors.grey,
   }) : super(
+          showLabels: showLabels,
           nodes: nodes,
           links: links,
           nodeColor: Colors.blue, // fallback node color
@@ -65,7 +67,8 @@ class InteractiveSankeyPainter extends SankeyPainter {
     // --- Draw colored nodes and labels with selection borders ---
     for (SankeyNode node in nodes) {
       final color = nodeColors[node.label] ?? Colors.blue;
-      final rect = Rect.fromLTWH(node.x0, node.y0, node.x1 - node.x0, node.y1 - node.y0);
+      final rect =
+          Rect.fromLTWH(node.x0, node.y0, node.x1 - node.x0, node.y1 - node.y0);
       final isSelected = selectedNodeId != null && node.id == selectedNodeId;
 
       canvas.drawRect(rect, Paint()..color = color);
@@ -81,7 +84,7 @@ class InteractiveSankeyPainter extends SankeyPainter {
       final isDark = color.computeLuminance() < 0.05;
       final textColor = isDark ? Colors.white : Colors.black;
 
-      if (node.label != null) {
+      if (node.label != null && showLabels) {
         final textSpan = TextSpan(
           text: node.label,
           style: TextStyle(
@@ -101,14 +104,16 @@ class InteractiveSankeyPainter extends SankeyPainter {
         const margin = 6.0;
         final labelY = rect.top + (rect.height - textPainter.height) / 2;
         final labelOffsetRight = Offset(rect.right + margin, labelY);
-        final labelOffsetLeft = Offset(rect.left - margin - textPainter.width, labelY);
+        final labelOffsetLeft =
+            Offset(rect.left - margin - textPainter.width, labelY);
 
         // Automatically choose a side that fits within the canvas
-        final labelOffset = (rect.right + margin + textPainter.width <= size.width)
-            ? labelOffsetRight
-            : (rect.left - margin - textPainter.width >= 0)
-                ? labelOffsetLeft
-                : labelOffsetRight;
+        final labelOffset =
+            (rect.right + margin + textPainter.width <= size.width)
+                ? labelOffsetRight
+                : (rect.left - margin - textPainter.width >= 0)
+                    ? labelOffsetLeft
+                    : labelOffsetRight;
 
         textPainter.paint(canvas, labelOffset);
       }

--- a/lib/sankey_helpers.dart
+++ b/lib/sankey_helpers.dart
@@ -110,7 +110,8 @@ Map<String, Color> generateDefaultNodeColorMap(List<SankeyNode> nodes) {
 /// the tap event in the canvas coordinate space
 int? detectTappedNode(List<SankeyNode> nodes, Offset tapPos) {
   for (var node in nodes) {
-    final rect = Rect.fromLTWH(node.x0, node.y0, node.x1 - node.x0, node.y1 - node.y0);
+    final rect =
+        Rect.fromLTWH(node.x0, node.y0, node.x1 - node.x0, node.y1 - node.y0);
     if (rect.contains(tapPos)) return node.id;
   }
   return null;
@@ -143,12 +144,14 @@ InteractiveSankeyPainter buildInteractiveSankeyPainter({
   required List<SankeyLink> links,
   required Map<String, Color> nodeColors,
   int? selectedNodeId,
+  final bool showLabels = true,
 }) {
   return InteractiveSankeyPainter(
     nodes: nodes,
     links: links,
     nodeColors: nodeColors,
     selectedNodeId: selectedNodeId,
+    showLabels: showLabels,
   );
 }
 
@@ -166,6 +169,7 @@ class SankeyDiagramWidget extends StatelessWidget {
   final int? selectedNodeId;
   final Function(int?)? onNodeTap;
   final Size size;
+  final bool showLabels;
 
   const SankeyDiagramWidget({
     Key? key,
@@ -174,6 +178,7 @@ class SankeyDiagramWidget extends StatelessWidget {
     this.selectedNodeId,
     this.onNodeTap,
     this.size = const Size(1000, 600),
+    this.showLabels = true,
   }) : super(key: key);
 
   @override
@@ -190,6 +195,7 @@ class SankeyDiagramWidget extends StatelessWidget {
           links: data.links,
           nodeColors: nodeColors,
           selectedNodeId: selectedNodeId,
+          showLabels: showLabels,
         ),
       ),
     );


### PR DESCRIPTION
- Added a new boolean parameter `showLabels` to the `InteractiveSankeyPainter` class to enable or disable the display of node labels.
- Updated the `_SankeyComplexDiagramWidgetState` in `main.dart` to set the `showLabels` parameter.
- Modified the `buildInteractiveSankeyPainter` function and `SankeyDiagramWidget` class in `sankey_helpers.dart` to include the `showLabels` parameter.
- Enhanced label positioning logic to respect the new `showLabels` flag.

## Summary by Sourcery

Add a showLabels toggle across the sankey rendering components to allow enabling or disabling node labels, and update drawing logic and example usage accordingly.

New Features:
- Introduce showLabels boolean parameter in InteractiveSankeyPainter to toggle node label visibility
- Expose showLabels parameter in buildInteractiveSankeyPainter and SankeyDiagramWidget API

Enhancements:
- Update label rendering logic to respect the showLabels flag during drawing
- Add showLabels configuration in example usage to control label display